### PR TITLE
Fix for crash when cards.xml is missing a <pt> tag

### DIFF
--- a/search_card.py
+++ b/search_card.py
@@ -282,8 +282,12 @@ class SearchCard:
 		if "Creature" in new_card.types:
 			#power or toughness can be an integer, '*', or {fraction}
 			#well, the last one's only for Little Girl ;)
-			p_t = node.find('pt').text.split('/')
-			new_card.power, new_card.toughness = map(maybe_to_int, p_t)
+			n = node.find('pt')
+			if n:
+				p_t = n.text.split('/')
+				new_card.power, new_card.toughness = map(maybe_to_int, p_t)
+			else:
+				new_card.power, new_card.toughness = (0,0)
 
 		if "Planeswalker" in new_card.types:
 			set_attribute("loyalty")


### PR DESCRIPTION
Found while testing with a recent cards.xml. Some cards were missing the <pt> node, set P/T to (0,0) when that's the case.

Example of the error:

looking at  Cardboard Carapace
Traceback (most recent call last):
  File "website.py", line 50, in <module>
    for n in root.findall("./cards/card")))
  File "website.py", line 50, in <genexpr>
    for n in root.findall("./cards/card")))
  File "/home/h/build/mtg-card-scan/search_card.py", line 285, in from_xml_node
    p_t = node.find('pt').text.split('/')
AttributeError: 'NoneType' object has no attribute 'text'
